### PR TITLE
Added Login and Register API

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -46,7 +46,11 @@ app.use(
 import { initializeApp } from 'firebase/app'
 initializeApp(firebaseConfig)
 
-// Test API
+/**
+ * Test API
+ * 
+ * @res Hello World!
+ */
 app.post('/helloWorld', (req: Request, res: Response) => {
   console.log('Hello!')
   res.json({ str: 'Hello World!' })
@@ -60,8 +64,19 @@ import {
 
 const auth = getAuth()
 
-// Login user with email
-// Expects input containing email and password
+/**
+ * API for logging in via an email and password
+ * 
+ * @req JSON containing "email" and "password" fields
+ * @res Stores the status of the request and a json containing either
+ *      the "userID" field if the request was valid, the "error" field 
+ *      if the API crashed, or the "general" field if the request was 
+ *      invalid. The following may be stored in the general field:
+ *          - Invalid Credentials: Email or Password was incorrect
+ *          - Invalid Email: The provided email is improperly formatted
+ *          - Missing Email: No email field was provided
+ *          - Missing Password: No password field was provided
+ */
 app.post('/loginWithEmail', (req: Request, res: Response) => {
   const user = req.body
   signInWithEmailAndPassword(auth, user.email, user.password)
@@ -81,6 +96,19 @@ app.post('/loginWithEmail', (req: Request, res: Response) => {
     })
 })
 
+/**
+ * API for registering via an email and password
+ * 
+ * @req JSON containing "email" and "password" fields
+ * @res Stores the status of the request and a json containing either
+ *      the "error" field if the API crashed, or the "general" field 
+ *      The following may be stored in the general field:
+ *          - User Created: The request was valid and a user was created
+ *          - Email in Use: The email provided is already tied to an account
+ *          - Invalid Email: The provided email is improperly formatted
+ *          - Missing Email: No email field was provided
+ *          - Missing Password: No password field was provided
+ */
 app.post('/registerWithEmail', (req: Request, res: Response) => {
   const newUser = req.body
   createUserWithEmailAndPassword(auth, newUser.email, newUser.password)

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,5 @@
-import * as functions from 'firebase-functions'
-import * as admin from 'firebase-admin'
+import { https } from 'firebase-functions'
+import admin from 'firebase-admin'
 
 import express, { Express, Request, Response } from 'express'
 const app: Express = express()
@@ -40,15 +40,64 @@ app.use(
     origin: allowedOriginsList,
     methods: allowedMethodsList,
     allowedHeaders: allowedHeadersList,
-  }),
+  })
 )
 
-import * as firebase from 'firebase/app'
-firebase.initializeApp(firebaseConfig)
+import { initializeApp } from 'firebase/app'
+initializeApp(firebaseConfig)
 
+// Test API
 app.post('/helloWorld', (req: Request, res: Response) => {
   console.log('Hello!')
   res.json({ str: 'Hello World!' })
 })
 
-exports.api = functions.https.onRequest(app)
+import {
+  getAuth,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+} from 'firebase/auth'
+
+const auth = getAuth()
+
+// Login user with email
+// Expects input containing email and password
+app.post('/loginWithEmail', (req: Request, res: Response) => {
+  const user = req.body
+  signInWithEmailAndPassword(auth, user.email, user.password)
+    .then((data) => {
+      return res.status(200).json({ userID: data.user.uid })
+    })
+    .catch((err) => {
+      if (err.code === 'auth/invalid-login-credentials')
+        return res.status(401).json({ general: 'Invalid Credentials' })
+      else if (err.code === 'auth/invalid-email')
+        return res.status(401).json({ general: 'Invalid Email' })
+      else if (err.code === 'auth/missing-email')
+        return res.status(401).json({ general: 'Missing Email' })
+      else if (err.code === 'auth/missing-password')
+        return res.status(401).json({ general: 'Missing Password' })
+      else return res.status(500).json({ error: err.code })
+    })
+})
+
+app.post('/registerWithEmail', (req: Request, res: Response) => {
+  const newUser = req.body
+  createUserWithEmailAndPassword(auth, newUser.email, newUser.password)
+    .then((data) => {
+      return res.status(201).json({ general: 'User Created' })
+    })
+    .catch((err) => {
+      if (err.code === 'auth/email-already-in-use')
+        return res.status(401).json({ general: 'Email in Use' })
+      else if (err.code === 'auth/invalid-email')
+        return res.status(401).json({ general: 'Invalid Email' })
+      else if (err.code === 'auth/missing-email')
+        return res.status(401).json({ general: 'Missing Email' })
+      else if (err.code === 'auth/missing-password')
+        return res.status(401).json({ general: 'Missing Password' })
+      else return res.status(500).json({ error: err.code })
+    })
+})
+
+exports.api = https.onRequest(app)

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -84,7 +84,7 @@ app.post('/loginWithEmail', (req: Request, res: Response) => {
 app.post('/registerWithEmail', (req: Request, res: Response) => {
   const newUser = req.body
   createUserWithEmailAndPassword(auth, newUser.email, newUser.password)
-    .then((data) => {
+    .then(() => {
       return res.status(201).json({ general: 'User Created' })
     })
     .catch((err) => {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -40,7 +40,7 @@ app.use(
     origin: allowedOriginsList,
     methods: allowedMethodsList,
     allowedHeaders: allowedHeadersList,
-  })
+  }),
 )
 
 import { initializeApp } from 'firebase/app'

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -48,7 +48,7 @@ initializeApp(firebaseConfig)
 
 /**
  * Test API
- * 
+ *
  * @res Hello World!
  */
 app.post('/helloWorld', (req: Request, res: Response) => {
@@ -66,11 +66,11 @@ const auth = getAuth()
 
 /**
  * API for logging in via an email and password
- * 
+ *
  * @req JSON containing "email" and "password" fields
  * @res Stores the status of the request and a json containing either
- *      the "userID" field if the request was valid, the "error" field 
- *      if the API crashed, or the "general" field if the request was 
+ *      the "userID" field if the request was valid, the "error" field
+ *      if the API crashed, or the "general" field if the request was
  *      invalid. The following may be stored in the general field:
  *          - Invalid Credentials: Email or Password was incorrect
  *          - Invalid Email: The provided email is improperly formatted
@@ -98,10 +98,10 @@ app.post('/loginWithEmail', (req: Request, res: Response) => {
 
 /**
  * API for registering via an email and password
- * 
+ *
  * @req JSON containing "email" and "password" fields
  * @res Stores the status of the request and a json containing either
- *      the "error" field if the API crashed, or the "general" field 
+ *      the "error" field if the API crashed, or the "general" field
  *      The following may be stored in the general field:
  *          - User Created: The request was valid and a user was created
  *          - Email in Use: The email provided is already tied to an account


### PR DESCRIPTION
Added login and register with email and password. The following was tested in postman:

Login with email:
- Logging in with an invalid email address (Response => "Invalid Email")
- Logging in with a valid email address that is not in the database (Response => "Invalid Credentials")
- Logging in with a valid email address but wrong password (Response => "Invalid Credentials")
- Logging in with a valid email address and valid password (Response => User ID)

Register with email:
- Registering with an invalid email address (Response => "Invalid Email")
- Registering with an email address already in use (Response => "Email in Use")
- Registering with a valid email address and valid password (Response => "User Create")

In addition, missing email and password fields in the input JSON are detected for both Login and Register with email.

Some formatting changes were also made to how I was importing certain functions.
