### PR TITLE
Switch "getUserData" API to get instead of post

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -162,7 +162,7 @@ app.post('/registerWithEmail', (req: Request, res: Response) => {
  *          - problemsTLE
  *          - ProblemsWrong
  */
-app.post('/getUserData', (req: Request, res: Response) => {
+app.get('/getUserData', (req: Request, res: Response) => {
   const userId: string = req.body.uid
   admin
     .auth()


### PR DESCRIPTION
Since this API is only retrieving data and does not manipulate anything on the backend, "GET" is more appropriate then "POST" for the http method type.