### PR TITLE
Revert getUserData to POST

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -162,7 +162,7 @@ app.post('/registerWithEmail', (req: Request, res: Response) => {
  *          - problemsTLE
  *          - ProblemsWrong
  */
-app.get('/getUserData', (req: Request, res: Response) => {
+app.post('/getUserData', (req: Request, res: Response) => {
   const userId: string = req.body.uid
   admin
     .auth()


### PR DESCRIPTION
Diff is self-explanatory. Tyler and I agreed this is best for security right now.

Profile Page is working again.
![image](https://github.com/ofast-team/functions/assets/51721851/ae51b9bc-d7e7-4600-909a-946944158bbc)
