### PR TITLE
Added getSubmission API

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -58,6 +58,7 @@ import { getProblems } from './getProblems'
 import { updateProblemData } from './updateProblemData'
 import { getProblemData } from './getProblemData'
 import { get_verdict, judge_is_online, submit } from './judge'
+import { getSubmissions } from './submissions'
 
 /**
  * API for logging in via an email and password
@@ -193,6 +194,7 @@ app.get('/judgeIsOnline', judge_is_online)
 /**
  * API for making a submission to the judge
  * @req JSON containing the following fields:
+ *          - uid: the user id for the user who is submitting
  *          - source_code: a base64 encoded string containing the user's code
  *          - language_id: a string containing the file ending of the language
  *          - inputs: an array of base64 encoded strings containing the input for the problem
@@ -230,5 +232,23 @@ app.post('/isVerified', isVerified)
  *      the user was sent a new verification email or not
  */
 app.post('/sendVerificationEmail', sendVerificationEmail)
+
+/**
+ * API for getting the submissions for each problem in a given list of problems
+ * @req JSON with the user id, the list of problemIds needed, and isBrief which
+ *      denotes whether the entire submissions is being queried for.
+ * @res A JSON file which will return a list of objects. Each of these objects
+ *      will have the field "problemId" which will be the problem identifier and
+ *      other parameters depending on the isBrief input parameter
+ *          - if isBrief is true, two addition parameters will be returned:
+ *            isSubmitted, which states whether the user has submitted on the
+ *            problem and isAccepted, which states whether the user has ACed on
+ *            the problem
+ *          - if isBrief is false, one additional parameter will be retuned:
+ *            "allSubmissions" which returns a list of all submission objects
+ *            for the current problem. Refer to the getVerdict for all information
+ *            contained in this object
+ */
+app.post('/getSubmissions', getSubmissions)
 
 exports.api = https.onRequest(app)

--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -61,7 +61,7 @@ export async function submit(req: Request, res: Response) {
   // TODO: Add the submission IDs to the user's data
   // TODO: For problems in the database, grab the data and use that for input/output
 
-  // C = 50, C++ = 54, Java = 62, Python:c 71 (does not use pypy in default judge0)
+  // C = 50, C++ = 54, Java = 62, Python: 71 (does not use pypy in default judge0)
 
   if (language == 50) {
     compiler_flags = '-g -O2 -std=c11'

--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -121,6 +121,8 @@ export async function submit(req: Request, res: Response) {
   }
   const date = new Date()
   addDoc(collection(db, 'Submissions'), {
+    uid: req.body.uid,
+    sourceCode: code,
     tokens: tokens,
     pending: true,
     date: date,

--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -61,7 +61,7 @@ export async function submit(req: Request, res: Response) {
   // TODO: Add the submission IDs to the user's data
   // TODO: For problems in the database, grab the data and use that for input/output
 
-  // C = 50, C++ = 54, Java = 62, Python: 71 (does not use pypy in default judge0)
+  // C = 50, C++ = 54, Java = 62, Python:c 71 (does not use pypy in default judge0)
 
   if (language == 50) {
     compiler_flags = '-g -O2 -std=c11'

--- a/functions/src/submissions.ts
+++ b/functions/src/submissions.ts
@@ -21,7 +21,7 @@ export async function getSubmissions(req: Request, res: Response) {
 
     await Promise.all(
       pIds.map(async (pId) => {
-        let submissionList: object[] = []
+        const submissionList: object[] = []
         const submDb = collection(db, 'Submissions')
         const queries = query(
           submDb,
@@ -34,10 +34,10 @@ export async function getSubmissions(req: Request, res: Response) {
 
         let problem = {}
         if (isBrief) {
-          let isSubmitted = submissionList.length > 0
+          const isSubmitted = submissionList.length > 0
           let isACed = false
           submissionList.forEach((submission) => {
-            let submissionJson = JSON.parse(JSON.stringify(submission))
+            const submissionJson = JSON.parse(JSON.stringify(submission))
             if (submissionJson.verdict == 3) isACed = true
           })
           problem = {

--- a/functions/src/submissions.ts
+++ b/functions/src/submissions.ts
@@ -1,0 +1,63 @@
+import { Request, Response } from 'express'
+import { collection, getDocs, query, where } from 'firebase/firestore'
+import { db } from './util'
+export async function getSubmissions(req: Request, res: Response) {
+  const uId = req.body.uid
+  const pIds: string[] = req.body.problemIds
+  const isBrief = req.body.isBrief
+  try {
+    let allSubmissions: object[] = []
+
+    const add = (submission: object) => {
+      return new Promise((resolve, reject) => {
+        if (submission !== null) {
+          allSubmissions.push(submission)
+          resolve(allSubmissions)
+        } else {
+          reject(new Error('invalid'))
+        }
+      })
+    }
+
+    await Promise.all(
+      pIds.map(async (pId) => {
+        let submissionList: object[] = []
+        const submDb = collection(db, 'Submissions')
+        console.log(uId + ' ' + pId)
+        const queries = query(
+          submDb,
+          where('problem_id', '==', pId),
+          where('uid', '==', uId),
+        )
+
+        const docs = await getDocs(queries)
+        docs.forEach((doc) => submissionList.push(doc.data()))
+
+        let problem = {}
+        if (isBrief) {
+          let isSubmitted = submissionList.length > 0
+          let isACed = false
+          submissionList.forEach((submission) => {
+            let submissionJson = JSON.parse(JSON.stringify(submission))
+            if (submissionJson.verdict == 3) isACed = true
+          })
+          problem = {
+            problemId: pId,
+            isSubmitted: isSubmitted,
+            isAccepted: isACed,
+          }
+        } else {
+          problem = {
+            problemId: pId,
+            submissions: submissionList,
+          }
+        }
+        console.log(problem)
+        await add(problem)
+      }),
+    )
+    res.status(200).json({ submissionsPerProblem: allSubmissions })
+  } catch (err) {
+    res.status(500).json({ error: err })
+  }
+}

--- a/functions/src/submissions.ts
+++ b/functions/src/submissions.ts
@@ -6,7 +6,7 @@ export async function getSubmissions(req: Request, res: Response) {
   const pIds: string[] = req.body.problemIds
   const isBrief = req.body.isBrief
   try {
-    let allSubmissions: object[] = []
+    const allSubmissions: object[] = []
 
     const add = (submission: object) => {
       return new Promise((resolve, reject) => {
@@ -23,7 +23,6 @@ export async function getSubmissions(req: Request, res: Response) {
       pIds.map(async (pId) => {
         let submissionList: object[] = []
         const submDb = collection(db, 'Submissions')
-        console.log(uId + ' ' + pId)
         const queries = query(
           submDb,
           where('problem_id', '==', pId),
@@ -52,7 +51,6 @@ export async function getSubmissions(req: Request, res: Response) {
             submissions: submissionList,
           }
         }
-        console.log(problem)
         await add(problem)
       }),
     )

--- a/functions/src/submissions.ts
+++ b/functions/src/submissions.ts
@@ -2,9 +2,9 @@ import { Request, Response } from 'express'
 import { collection, getDocs, query, where } from 'firebase/firestore'
 import { db } from './util'
 export async function getSubmissions(req: Request, res: Response) {
-  const uId = req.body.uid
+  const uId: number | string = req.body.uid
   const pIds: string[] = req.body.problemIds
-  const isBrief = req.body.isBrief
+  const isBrief: boolean = req.body.isBrief
   try {
     const allSubmissions: object[] = []
 


### PR DESCRIPTION
This API takes in a user ID, problem ID, and a "isBrief" flag and returns data about a person's submissions on the corresponding problems.

The isBrief flag denotes how much data gets returned. If it is true, then for each problem, the API will return whether or not the user has submitted on that problem, and whether or not that user has ACed on that problem. If it is false, then for each problem, the API will return a list of all submission data stored in our database. If needed this can be pruned down.

Below is the testing of the function on several cases:

The user has submitted on one problem (isBrief = false)
![notbrief_one_submission](https://github.com/ofast-team/functions/assets/77948992/baa905d0-6472-41a2-957e-c4b870fa455e)

The user has submitted on two problems (isBrief = false)
![notbrief_two_submissions](https://github.com/ofast-team/functions/assets/77948992/abf76f66-32b9-4356-97e7-af7430b5f636)

The user has submitted on one problem and has not ACed on that problem (isBrief = true)
![brief_one_submitted_one_aced](https://github.com/ofast-team/functions/assets/77948992/07ec2886-1f14-48e7-a0c8-d3f25f35f00c)

The user has submitted on two different problems but only ACed on one of them
![brief_two_submitted_one_aced](https://github.com/ofast-team/functions/assets/77948992/e9fd6a2f-78ec-4d6e-9161-bab3436f8c5b)
