### PR TITLE
Added support for time limits

### DIFF
--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -49,7 +49,7 @@ async function get_data(problem_id: string): Promise<{
 }> {
   const inputs: string[] = []
   const outputs: string[] = []
-  let time_limit: number = 1
+  let time_limit: number = DEFAULT_TIME_LIMIT
   // get the data from the database
   await getDoc(doc(db, 'Problems', problem_id))
     .then((problem) => {

--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -92,6 +92,7 @@ export async function get_time_limit(problem_id: string) {
     .catch(() => {
       return DEFAULT_TIME_LIMIT
     })
+    return time_limit
 }
 
 export async function submit(req: Request, res: Response) {
@@ -142,7 +143,7 @@ export async function submit(req: Request, res: Response) {
     inputs = data.inputs
     outputs = data.outputs
     error = data.error
-    time_limit = get_time_limit(problem_id)
+    time_limit = await get_time_limit(problem_id)
   }
 
   if (error != '' && error != undefined) {

--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -1,6 +1,12 @@
 import { Request, Response } from 'express'
 import { doc, updateDoc, addDoc, getDoc, collection } from 'firebase/firestore'
-import { MAX_CASES, MAX_TIME_LIMIT, db, judge_url } from './util'
+import {
+  DEFAULT_TIME_LIMIT,
+  MAX_CASES,
+  MAX_TIME_LIMIT,
+  db,
+  judge_url,
+} from './util'
 import { Buffer } from 'buffer'
 import axios from 'axios'
 
@@ -84,6 +90,9 @@ export async function submit(req: Request, res: Response) {
   }
   if (language_string == undefined) {
     missing.push('Missing language')
+  }
+  if (time_limit == undefined) {
+    time_limit = DEFAULT_TIME_LIMIT
   }
 
   if (problem_id == undefined) {

--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -92,7 +92,7 @@ export async function get_time_limit(problem_id: string) {
     .catch(() => {
       return DEFAULT_TIME_LIMIT
     })
-    return time_limit
+  return time_limit
 }
 
 export async function submit(req: Request, res: Response) {

--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -123,9 +123,6 @@ export async function submit(req: Request, res: Response) {
       missing.push('Missing outputs array')
     }
 
-    if (time_limit == undefined) {
-      missing.push('Missing time limit')
-    }
     if (missing.length > 0) {
       return res.status(400).json({ error: missing })
     }

--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -89,7 +89,7 @@ export async function get_time_limit(problem_id: string) {
       }
       return time_limit
     })
-    .catch((err) => {
+    .catch(() => {
       return DEFAULT_TIME_LIMIT
     })
 }

--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -83,15 +83,15 @@ async function get_data(problem_id: string): Promise<{
 export async function get_time_limit(problem_id: string) {
   let time_limit = DEFAULT_TIME_LIMIT
   await getDoc(doc(db, 'Problems', problem_id))
-  .then((problem) => {
-    if (problem.exists()) {
-      time_limit = problem.data().timeLimit
-    }
-    return time_limit
-  })
-  .catch((err) => {
-    return DEFAULT_TIME_LIMIT;
-  })
+    .then((problem) => {
+      if (problem.exists()) {
+        time_limit = problem.data().timeLimit
+      }
+      return time_limit
+    })
+    .catch((err) => {
+      return DEFAULT_TIME_LIMIT
+    })
 }
 
 export async function submit(req: Request, res: Response) {

--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -55,7 +55,7 @@ async function get_data(problem_id: string): Promise<{
     .then((problem) => {
       if (problem.exists()) {
         const data = problem.data().sampleData
-        time_limit = data.time_limit
+        time_limit = data.timeLimit
         for (let i = 0; i < data.length; i++) {
           inputs.push(Buffer.from(data[i].input).toString('base64'))
           outputs.push(Buffer.from(data[i].output).toString('base64'))
@@ -134,7 +134,7 @@ export async function submit(req: Request, res: Response) {
     inputs = data.inputs
     outputs = data.outputs
     error = data.error
-    time_limit = data.time_limit
+    time_limit = data.timeLimit
   }
 
   if (error != '' && error != undefined) {

--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -134,7 +134,7 @@ export async function submit(req: Request, res: Response) {
     inputs = data.inputs
     outputs = data.outputs
     error = data.error
-    time_limit = data.timeLimit
+    time_limit = data.time_limit
   }
 
   if (error != '' && error != undefined) {

--- a/functions/src/util.ts
+++ b/functions/src/util.ts
@@ -20,3 +20,4 @@ export const db: Firestore = getFirestore(appInit)
 export const judge_url = 'http://174.138.86.255:2358'
 
 export const MAX_CASES = 100
+export const MAX_TIME_LIMIT = 10

--- a/functions/src/util.ts
+++ b/functions/src/util.ts
@@ -21,3 +21,4 @@ export const judge_url = 'http://174.138.86.255:2358'
 
 export const MAX_CASES = 100
 export const MAX_TIME_LIMIT = 10
+export const DEFAULT_TIME_LIMIT = 1


### PR DESCRIPTION
Currently I have the max time limit at 10 seconds, if someone submits 100 cases with 10s time limit then that would take like 8 minutes to run so not sure if we want to lower that or find some middle ground with that.  Problems are also going to need a time limit in the database which I'm sure won't be hard to add, but will need to be changed.  Verdict 5 is TLE.

(All the code used is just an empty while loop)
### 1s time limit
![image](https://github.com/ofast-team/functions/assets/56406616/875064a9-a3d0-4fba-9a75-b8ad604d1243)
![image](https://github.com/ofast-team/functions/assets/56406616/cde843c8-0031-4888-b571-73be8e2aec51)

### 10s time limit
![image](https://github.com/ofast-team/functions/assets/56406616/1372ded3-1126-4cb6-a6c2-9a899692be6b)
![image](https://github.com/ofast-team/functions/assets/56406616/e2b6e782-d15f-45dd-8272-34cfcaf0ed33)

### Time limit gets capped at max (10) seconds
![image](https://github.com/ofast-team/functions/assets/56406616/020ab7f2-29e7-4fce-ba91-d10ed1ba0592)
![image](https://github.com/ofast-team/functions/assets/56406616/53cb1817-0a23-45f4-92ff-295053cd14df)

### Default 1s time limit if none is provided
![image](https://github.com/ofast-team/functions/assets/56406616/502df60f-700c-4bcc-b359-7eef1bc97535)
![image](https://github.com/ofast-team/functions/assets/56406616/3f3a1112-f0b2-4f28-95f6-d830192c51b7)

### Time limit defaults to 1s, but should be grabbing time limit from database if it exists for problems
![image](https://github.com/ofast-team/functions/assets/56406616/5eaffd40-595c-4c9e-8969-8de9edf3c0ce)
![image](https://github.com/ofast-team/functions/assets/56406616/d66c4f07-37e7-4bc8-a52c-8d92949e6e04)
