### PR TITLE
Get real data instead of sample data

### DIFF
--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -43,10 +43,10 @@ async function get_data(problem_id: string): Promise<{
   const inputs: string[] = []
   const outputs: string[] = []
   // get the data from the database
-  await getDoc(doc(db, 'Problems', problem_id))
+  await getDoc(doc(db, 'ProblemData', problem_id))
     .then((problem) => {
       if (problem.exists()) {
-        const data = problem.data().sampleData
+        const data = problem.data().data
         for (let i = 0; i < data.length; i++) {
           inputs.push(Buffer.from(data[i].input).toString('base64'))
           outputs.push(Buffer.from(data[i].output).toString('base64'))


### PR DESCRIPTION

API now grabs all 29, not just the 3 samples!
![image](https://github.com/ofast-team/functions/assets/51721851/80d99555-b5c5-4f76-874f-96867158cb8c)
