### PR TITLE
getVerdict API now updated verdict count

### DIFF
--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -1,5 +1,12 @@
 import { Request, Response } from 'express'
-import { doc, updateDoc, addDoc, getDoc, collection } from 'firebase/firestore'
+import {
+  doc,
+  updateDoc,
+  addDoc,
+  getDoc,
+  collection,
+  increment,
+} from 'firebase/firestore'
 import { MAX_CASES, db, judge_url } from './util'
 import { Buffer } from 'buffer'
 import axios from 'axios'
@@ -281,9 +288,46 @@ export async function get_verdict(req: Request, res: Response) {
           new_object.pending = pending
           new_object.memory = memory
 
-          updateDoc(doc(db, 'Submissions', submission_id), new_object)
+          let verdictUpdate = {}
+          if (!pending) {
+            switch (verdict) {
+              case 3: {
+                verdictUpdate = { problemsAccepted: increment(1) }
+                break
+              }
+              case 4: {
+                verdictUpdate = { problemsWrong: increment(1) }
+                break
+              }
+              case 5: {
+                verdictUpdate = { problemsTLE: increment(1) }
+                break
+              }
+              case 6: {
+                verdictUpdate = { problemsCTE: increment(1) }
+                break
+              }
+              default: {
+                verdictUpdate = { problemsRTE: increment(1) }
+                break
+              }
+            }
+            verdictUpdate = {
+              ...verdictUpdate,
+              problemsAttempted: increment(1),
+            }
+          }
+
+          const userId = new_object.uid
+          updateDoc(doc(db, 'UserData', userId), verdictUpdate)
             .then(() => {
-              return res.status(200).json(new_object)
+              updateDoc(doc(db, 'Submissions', submission_id), new_object)
+                .then(() => {
+                  return res.status(200).json(new_object)
+                })
+                .catch((err) => {
+                  return res.status(500).json({ error: err })
+                })
             })
             .catch((err) => {
               return res.status(500).json({ error: err })

--- a/functions/src/judge.ts
+++ b/functions/src/judge.ts
@@ -336,29 +336,29 @@ export async function get_verdict(req: Request, res: Response) {
           if (!pending) {
             switch (verdict) {
               case 3: {
-                verdictUpdate = { problemsAccepted: increment(1) }
+                verdictUpdate = { submissionsAccepted: increment(1) }
                 break
               }
               case 4: {
-                verdictUpdate = { problemsWrong: increment(1) }
+                verdictUpdate = { submissionsWrong: increment(1) }
                 break
               }
               case 5: {
-                verdictUpdate = { problemsTLE: increment(1) }
+                verdictUpdate = { submissionsTLE: increment(1) }
                 break
               }
               case 6: {
-                verdictUpdate = { problemsCTE: increment(1) }
+                verdictUpdate = { submissionsCTE: increment(1) }
                 break
               }
               default: {
-                verdictUpdate = { problemsRTE: increment(1) }
+                verdictUpdate = { submissionsRTE: increment(1) }
                 break
               }
             }
             verdictUpdate = {
               ...verdictUpdate,
-              problemsAttempted: increment(1),
+              numSubmissions: increment(1),
             }
           }
 

--- a/functions/src/submissions.ts
+++ b/functions/src/submissions.ts
@@ -75,6 +75,14 @@ export async function getSubmissions(req: Request, res: Response) {
         }
 
         if (!isBrief) {
+          submissionList.sort((a, b) => {
+            const timeA = Object(a)['date']
+            const timeB = Object(b)['date']
+            if (timeA < timeB) return -1
+            else if (timeA == timeB) return 0
+            else return 1
+          })
+
           problem = {
             ...problem,
             submissions: submissionList,


### PR DESCRIPTION
The getVerdict API will now autmatically update each respective data field in userData. Below shows user data after a submit of each data type.

Before any submit:
![initial_verdict_data](https://github.com/ofast-team/functions/assets/77948992/6a33f359-bec1-4067-ba89-106608f32244)

Submitting a RTE:
![submitted_RTE](https://github.com/ofast-team/functions/assets/77948992/8800279b-a022-4675-bea3-3b596ba63035)

Submitting a CTE:
![submitted_CTE](https://github.com/ofast-team/functions/assets/77948992/8af4bf98-3997-4194-aa38-1765b53a787a)

Submitting a WA:
![submitted_WA](https://github.com/ofast-team/functions/assets/77948992/e506222f-784f-49da-ae93-78b34789145a)

Submitting a TLE:
![submitted_TLE](https://github.com/ofast-team/functions/assets/77948992/c7da94ea-959d-4718-ad8d-0d00693debc8)

Submitting a AC:
![submitted_AC](https://github.com/ofast-team/functions/assets/77948992/a28c6e77-1358-4343-b09c-4081295f6e6c)
