### PR TITLE
Sort Submissions in Reverse Order

### DIFF
--- a/functions/src/submissions.ts
+++ b/functions/src/submissions.ts
@@ -78,7 +78,7 @@ export async function getSubmissions(req: Request, res: Response) {
           submissionList.sort((a, b) => {
             const timeA = Object(a)['date']
             const timeB = Object(b)['date']
-            if (timeA < timeB) return -1
+            if (timeA > timeB) return -1
             else if (timeA == timeB) return 0
             else return 1
           })


### PR DESCRIPTION
Title explains itself. The API was previously returning the submissions in order of **_increasing_** date